### PR TITLE
feat: Implement model training stage

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,17 @@
 # main.py
+import sys
+
 from fraud_detector import logger
-from fraud_detector.pipeline.stage_01_data_ingestion import DataIngestionTrainingPipeline
-from fraud_detector.pipeline.stage_02_data_transformation import DataTransformationTrainingPipeline
 
 # Import your custom exception
 from fraud_detector.exception import CustomException
-import sys
+from fraud_detector.pipeline.stage_01_data_ingestion import (
+    DataIngestionTrainingPipeline,
+)
+from fraud_detector.pipeline.stage_02_data_transformation import (
+    DataTransformationTrainingPipeline,
+)
+from fraud_detector.pipeline.stage_03_model_training import ModelTrainingPipeline
 
 # Name of the current stage for the log
 # --- Stage 1: Data Ingestion ---
@@ -31,6 +37,21 @@ try:
     obj.main()
     logger.info(
         f">>>>>> Stage {STAGE_NAME_TRANSFORMATION} completed <<<<<<\n\nx==========x")
+
+except Exception as e:
+    logger.exception(e)
+    raise CustomException(e, sys)
+
+# --- Stage 3: Model training  ---
+
+STAGE_NAME_TRAINING = "Model Training Stage"
+try:
+    logger.info(f"********************")
+    logger.info(f">>>>>> Stage {STAGE_NAME_TRAINING} started <<<<<<")
+    obj = ModelTrainingPipeline()
+    obj.main()
+    logger.info(
+        f">>>>>> Stage {STAGE_NAME_TRAINING} completed <<<<<<\n\nx==========x")
 
 except Exception as e:
     logger.exception(e)

--- a/params.yaml
+++ b/params.yaml
@@ -16,6 +16,18 @@ metrics:
   threshold: 0.5 # Threshold for binary classification (if applicable)
 
 
+XGBoost:
+  objective: 'binary:logistic' # For binary classification
+  n_estimators: 100            # Number of trees
+  learning_rate: 0.1           # Learning rate
+  max_depth: 5                 # Maximum depth of trees
+  subsample: 0.8               # Subsampling of training instances
+  colsample_bytree: 0.8        # Submuestreo de columnas al construir cada árbol
+ # You can add more XGBoost parameters here, such as gamma, reg_alpha, reg_lambda, scale_pos_weight
+ # scale_pos_weight is very important for class imbalance in XGBoost
+ # scale_pos_weight: 99.87 # If 0.13% are positive, the ratio is (100-0.13)/0.13
+
+
 
 data_transformation:
   numerical_features: ["amount", "oldbalanceOrg", "newbalanceOrig", "oldbalanceDest", "newbalanceDest"]
@@ -23,3 +35,6 @@ data_transformation:
   drop_columns: ["nameOrig", "nameDest", "isFlaggedFraud", "step"] # 'step' if the EDA confirms that there is no time dependency
   # You can add parameters here for SMOTE or other techniques if they are used in the pipeline
   # For example, sampling_strategy: "auto" for SMOTE
+
+
+

--- a/src/fraud_detector/components/data_ingestion.py
+++ b/src/fraud_detector/components/data_ingestion.py
@@ -1,8 +1,9 @@
 # src/fraud_detector/components/data_ingestion.py
 import os
 import urllib.request as request  # # To download files from URLs
-import pathlib as Path
+from pathlib import Path
 from zipfile import ZipFile  # If your dataset is a .zip (common in Kaggle)
+
 from fraud_detector import logger
 from fraud_detector.entity.config_entity import DataIngestionConfig
 from fraud_detector.utils.common import get_size  # A utility we created

--- a/src/fraud_detector/components/data_transformation.py
+++ b/src/fraud_detector/components/data_transformation.py
@@ -1,17 +1,20 @@
 # src/fraud_detector/components/data_transformation.py
 import os
-import pandas as pd
+import sys
+from pathlib import Path
+
 import numpy as np
-import pathlib as Path
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import StandardScaler, OneHotEncoder
+import pandas as pd
 from sklearn.compose import ColumnTransformer
+from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline  # We will use this for the preprocessor
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
 from fraud_detector import logger
 from fraud_detector.entity.config_entity import DataTransformationConfig
-from fraud_detector.utils.common import save_bin  # To save preprocessor
 from fraud_detector.exception import CustomException
-import sys
+from fraud_detector.utils.common import save_bin  # To save preprocessor
+
 # from imblearn.over_sampling import SMOTE # Uncomment if you're using SMOTE here
 # from imblearn.combine import SMOTETomek # Or some combination
 

--- a/src/fraud_detector/components/model_trainer.py
+++ b/src/fraud_detector/components/model_trainer.py
@@ -1,0 +1,118 @@
+# src/fraud_detector/components/model_trainer.py
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import xgboost as xgb  # Import XGBoost model
+
+# Import ColumnTransformer if the preprocessor is included in the same training pipeline
+from sklearn.compose import ColumnTransformer
+from sklearn.linear_model import LogisticRegression
+
+# To create a complete pipeline (preprocessor + model)
+from sklearn.pipeline import Pipeline
+
+from fraud_detector import logger
+from fraud_detector.entity.config_entity import ModelTrainingConfig
+from fraud_detector.exception import CustomException
+
+# To save the trained model
+from fraud_detector.utils.common import load_bin, save_bin
+
+
+class ModelTrainer:
+    def __init__(self, config: ModelTrainingConfig):
+        self.config = config
+        logger.info(f"Model Training component initialized.")
+
+    def train(self, X_train: np.ndarray, y_train: pd.Series, preprocessor_path: Path):
+        try:
+            # Validate the inputs
+            if X_train is None or y_train is None:
+                raise ValueError("Training data cannot be None")
+
+            logger.info(f"Training data shape: {X_train.shape}")
+            logger.info(
+                f"Target distribution: {y_train.value_counts().to_dict()}")
+
+            # Load the saved preprocessor
+            preprocessor_obj = load_bin(preprocessor_path)
+            logger.info(
+                f"Preprocessor loaded successfully from {preprocessor_path}")
+
+            # --- Model 1: Logistic Regression ---
+            logger.info("Training Logistic Regression model...")
+            # The preprocessor was already applied in data_transformation, so X_train is already transformed.
+            # Here, the pipeline would be just the classifier if X_train is already preprocessed.
+            # For an end-to-end pipeline that includes the preprocessor, then
+            # X_train and X_test would be the original data frames, and the preprocessor would be applied here.
+
+            # NOTE: X_train already transformed (as returned by DataTransformation)
+            # In this case, the training pipeline would only be the classifier:
+            lr_classifier = LogisticRegression(
+                solver=self.config.solver,
+                C=self.config.C,
+                class_weight=self.config.class_weight,
+                random_state=self.config.random_state,
+                max_iter=self.config.max_iter
+            )
+            # Train with already transformed data
+            lr_classifier.fit(X_train, y_train)
+            logger.info("Logistic Regression model trained.")
+
+            # Save only the Logistic Regression classifier
+            lr_model_path = os.path.join(
+                self.config.root_dir, "logistic_regression_model.joblib")
+            save_bin(lr_classifier, lr_model_path)
+            logger.info(f"Logistic Regression model saved at: {lr_model_path}")
+
+            # --- Model 2: XGBoost ---
+            # Important: For XGBoost, if you use scale_pos_weight, calculate the class proportion
+            # Calculating scale_pos_weight for unbalanced datasets
+            num_positive = y_train.sum()
+            num_negative = len(y_train) - num_positive
+            scale_pos_weight_value = num_negative / num_positive if num_positive > 0 else 1
+            logger.info(
+                f"Calculated scale_pos_weight for XGBoost: {scale_pos_weight_value:.4f}")
+
+            xgb_classifier = xgb.XGBClassifier(
+                objective=self.config.xgb_objective,
+                n_estimators=self.config.xgb_n_estimators,
+                learning_rate=self.config.xgb_learning_rate,
+                max_depth=self.config.xgb_max_depth,
+                subsample=self.config.xgb_subsample,
+                colsample_bytree=self.config.xgb_colsample_bytree,
+                random_state=self.config.random_state,
+                scale_pos_weight=scale_pos_weight_value # comment or uncomment and pass if calculated
+            )
+            logger.info("Training XGBoost model...")
+            # Train with already transformed data
+            xgb_classifier.fit(X_train, y_train)
+            logger.info("XGBoost model trained.")
+
+            # Save the XGBoost classifier
+            xgb_model_path = os.path.join(
+                self.config.root_dir, "xgboost_model.joblib")
+            save_bin(xgb_classifier, xgb_model_path)
+            logger.info(f"XGBoost model saved at: {xgb_model_path}")
+
+            # NOTE: For prediction, you'll need to know which model you'll use.
+            # You could decide here, or use a specific model in the prediction pipeline.
+            # For now, we'll save both, and the evaluation stage will choose or evaluate both.
+
+            # Also save the preprocessor in the models directory for inference
+            preprocessor_copy_path = os.path.join(
+                self.config.root_dir, "preprocessor.joblib")
+            save_bin(preprocessor_obj, preprocessor_copy_path)
+            logger.info(f"Preprocessor copied to: {preprocessor_copy_path}")
+
+            return {
+                'logistic_regression_path': lr_model_path,
+                'xgboost_path': xgb_model_path,
+                'preprocessor_path': preprocessor_copy_path
+            }
+
+        except Exception as e:
+            raise CustomException(e, sys)

--- a/src/fraud_detector/config/configuration.py
+++ b/src/fraud_detector/config/configuration.py
@@ -1,10 +1,14 @@
 # src/fraud_detector/config/configuration.py
 from fraud_detector.constants import *
-from fraud_detector.utils.common import read_yaml, create_directories
-from fraud_detector.entity.config_entity import (DataIngestionConfig,
-                                                 DataTransformationConfig,
-                                                 ModelTrainingConfig,
-                                                 ModelEvaluationConfig)  # Import your new entities
+from fraud_detector.entity.config_entity import (
+    ModelEvaluationConfig,  # Import your new entities
+)
+from fraud_detector.entity.config_entity import (
+    DataIngestionConfig,
+    DataTransformationConfig,
+    ModelTrainingConfig,
+)
+from fraud_detector.utils.common import create_directories, read_yaml
 
 
 class ConfigurationManager:
@@ -44,8 +48,8 @@ class ConfigurationManager:
             root_dir=Path(config.root_dir),
             processed_data_file=Path(config.processed_data_file),
             preprocessor_name=config.preprocessor_name,
-            numerical_features=list(params.numerical_features),
-            categorical_features=list(params.categorical_features),
+            numerical_features=list(params.numerical_features), # To access for data_transformation
+            categorical_features=list(params.categorical_features), # To access for data_transformation
             drop_columns=list(params.drop_columns),
             # Access directly from self.params.test_size
             test_size=float(self.params.test_size),
@@ -54,5 +58,33 @@ class ConfigurationManager:
         )
 
         return data_transformation_config
+
+    def get_model_training_config(self) -> ModelTrainingConfig:
+        config = self.config.model_training  # Section config.yaml
+        # Logistic Regression section - params.yaml
+        params = self.params.LogisticRegression
+        xgb_params = self.params.XGBoost  # XGBoost section - params.yaml
+
+        create_directories([config.root_dir])
+
+        model_training_config = ModelTrainingConfig(
+            root_dir=Path(config.root_dir),
+            trained_model_name=config.trained_model_name,
+            # Parameters for Logistic Regression
+            solver=params.solver,
+            C=float(params.C),
+            class_weight=params.class_weight,
+            random_state=int(params.random_state),
+            max_iter=int(params.max_iter),
+            # Parameters for XGBoost
+            xgb_objective=xgb_params.objective,
+            xgb_n_estimators=int(xgb_params.n_estimators),
+            xgb_learning_rate=float(xgb_params.learning_rate),
+            xgb_max_depth=int(xgb_params.max_depth),
+            xgb_subsample=float(xgb_params.subsample),
+            xgb_colsample_bytree=float(xgb_params.colsample_bytree)
+        )
+
+        return model_training_config
 
     # ... (we will add methods for training and evaluation later)

--- a/src/fraud_detector/entity/config_entity.py
+++ b/src/fraud_detector/entity/config_entity.py
@@ -24,8 +24,22 @@ class DataTransformationConfig:
 
 @dataclass(frozen=True)
 class ModelTrainingConfig:
-    # We will add this entity later
-    pass
+    root_dir: Path
+    trained_model_name: str
+    # Parameters for Logistic Regression
+    solver: str
+    C: float
+    class_weight: str  # O dict manual weights
+    random_state: int
+    max_iter: int
+    # Paramters for XGBoost
+    xgb_objective: str
+    xgb_n_estimators: int
+    xgb_learning_rate: float
+    xgb_max_depth: int
+    xgb_subsample: float
+    xgb_colsample_bytree: float
+    # Add more parameters for XGBoost here
 
 
 @dataclass(frozen=True)

--- a/src/fraud_detector/exception/__init__.py
+++ b/src/fraud_detector/exception/__init__.py
@@ -1,6 +1,5 @@
 import sys
 
-
 """
 Function to get the details of the error
 """

--- a/src/fraud_detector/pipeline/stage_01_data_ingestion.py
+++ b/src/fraud_detector/pipeline/stage_01_data_ingestion.py
@@ -1,7 +1,6 @@
 from fraud_detector import logger
-from fraud_detector.config.configuration import ConfigurationManager
 from fraud_detector.components.data_ingestion import DataIngestion
-
+from fraud_detector.config.configuration import ConfigurationManager
 
 STAGE_NAME = "Data Ingestion Stage"
 

--- a/src/fraud_detector/pipeline/stage_02_data_transformation.py
+++ b/src/fraud_detector/pipeline/stage_02_data_transformation.py
@@ -1,7 +1,10 @@
-from fraud_detector import logger
-from fraud_detector.config.configuration import ConfigurationManager
-from fraud_detector.components.data_transformation import DataTransformation
+import os
 
+import numpy as np
+
+from fraud_detector import logger
+from fraud_detector.components.data_transformation import DataTransformation
+from fraud_detector.config.configuration import ConfigurationManager
 
 STAGE_NAME = "Data Ingestion Stage"
 
@@ -16,13 +19,26 @@ class DataTransformationTrainingPipeline:
         data_transformation = DataTransformation(
             config=data_transformation_config)
 
-        # La ruta al archivo de datos de entrada debe venir de la etapa de ingesta
-        # Por simplicidad, la tomamos directamente de config.yaml/data_ingestion.local_data_file
-        # En un pipeline DVC real, esto lo manejaría DVC
-        # Para obtener la ruta del archivo ingestado
+        # The path to the input data file must come from the ingestion stage
+        # For simplicity, we take it directly from config.yaml/data_ingestion.local_data_file
+        # In a real DVC pipeline, this would be handled by DVC
+        # To get the path of the ingested file
         data_ingestion_config = config.get_data_ingestion_config()
-        data_transformation.initiate_data_transformation(
-            data_ingestion_config.local_data_file)
+        X_train, X_test, y_train, y_test, preprocessor_path = \
+            data_transformation.initiate_data_transformation(
+                data_ingestion_config.local_data_file)
+
+        # Now that the variables are defined, we save them.
+        # The preprocessor is saved in its already defined location in the component.
+        # And the transformed data in .npy files to pass them on to the next stage.
+        np.save(os.path.join(
+            data_transformation_config.root_dir, "X_train.npy"), X_train)
+        np.save(os.path.join(
+            data_transformation_config.root_dir, "X_test.npy"), X_test)
+        np.save(os.path.join(
+            data_transformation_config.root_dir, "y_train.npy"), y_train)
+        np.save(os.path.join(
+            data_transformation_config.root_dir, "y_test.npy"), y_test)
 
 
 """
@@ -39,3 +55,5 @@ if __name__ == '__main__':
     except Exception as e:
         logger.exception(e)
         raise e
+
+

--- a/src/fraud_detector/pipeline/stage_03_model_training.py
+++ b/src/fraud_detector/pipeline/stage_03_model_training.py
@@ -1,0 +1,57 @@
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from fraud_detector import logger
+from fraud_detector.components.model_trainer import ModelTrainer
+from fraud_detector.config.configuration import ConfigurationManager
+
+STAGE_NAME = "Model Training Stage"
+
+
+class ModelTrainingPipeline:
+    def __init__(self):
+        pass
+
+    def main(self):
+        config = ConfigurationManager()
+        model_training_config = config.get_model_training_config()
+
+        # Load the preprocessed data saved by the previous step
+        # To get the path where it was saved
+        data_transformation_config = config.get_data_transformation_config()
+        X_train = np.load(os.path.join(
+            data_transformation_config.root_dir, "X_train.npy"))
+        X_test = np.load(os.path.join(
+            data_transformation_config.root_dir, "X_test.npy"))
+        y_train = np.load(os.path.join(
+            data_transformation_config.root_dir, "y_train.npy"))
+        y_test = np.load(os.path.join(
+            data_transformation_config.root_dir, "y_test.npy"))
+
+        # The path to the preprocessor is also required
+        preprocessor_path = os.path.join(
+            data_transformation_config.root_dir, data_transformation_config.preprocessor_name)
+
+        model_trainer = ModelTrainer(config=model_training_config)
+        model_trainer.train(X_train=X_train, y_train=pd.Series(
+            y_train), preprocessor_path=Path(preprocessor_path))
+
+
+"""
+Python will start reading from here only
+"""
+if __name__ == '__main__':
+    try:
+        logger.info(f">>>>>> stage {STAGE_NAME} started <<<<<<")
+        obj = ModelTrainingPipeline()
+        obj.main()
+        logger.info(
+            f">>>>>> stage {STAGE_NAME} completed <<<<<<\n\nx========x")
+
+    except Exception as e:
+        logger.exception(e)
+        raise e

--- a/src/fraud_detector/utils/common.py
+++ b/src/fraud_detector/utils/common.py
@@ -1,12 +1,14 @@
+import json
 import os
-from ensure import ensure_annotations
+from pathlib import Path
+
+import joblib  # To have and load model/preprocesors of sckit-learn
+import yaml
 from box import ConfigBox
 from box.exceptions import BoxValueError
-from pathlib import Path
-import yaml
-import json
+from ensure import ensure_annotations
+
 from fraud_detector import logger
-import joblib  # To have and load model/preprocesors of sckit-learn
 
 
 @ensure_annotations
@@ -79,16 +81,16 @@ def load_json(path: str) -> ConfigBox:
 
 
 @ensure_annotations
-def save_bin(data: object, path: Path):
+def save_bin(data: object, path: str):
     """
     Saves data as a binary file (e.g., trained model, preprocessor).
 
     Args:
         data (object): Data to be saved (e.g., model, preprocessor).
-        path (Path): Path to binary file.
-    """
+        path (str): Path to binary file.
+    # """
     path = Path(path)  # Ensures that even if someone passes a str, it becomes
-    # Create directories if they don't exist
+    # # Create directories if they don't exist
     path.parent.mkdir(parents=True, exist_ok=True)
     joblib.dump(data, path)
     logger.info(f"binary file saved at: {path}")


### PR DESCRIPTION

## Added
- pipeline/stage_03_model_training.py: -> Pipleline created for stage 3
- components/model_trainer.py: -> Logic to train the model with LR and XGBoost

## Changes
- config/config.yaml: -> get_model_training_config() added to work with the stage 03 pipeline
- entity/config_entity: -> Enitity ModelTrainingConfig updated to work with Logistic Regresion and XGBoost
- utils/common.py: -> save_bin() ensruing to accept Path if someone passes a str
- __init.py: -> Renamed to __init__.py
- main.py: ->  STAGE_NAME_TRAINING added. 
- params.yaml: -> XGBoost parameters added to train two different models.


## How to run?
- Make sure you have the fraud.csv dataset.
- Run  `python.\src\fraud_detector\pipeline\stage_03_model_training.py `